### PR TITLE
Bug Fixed pull request

### DIFF
--- a/MediaPicker/multiple-media-picker/src/main/java/com/erikagtierrez/multiple_media_picker/OpenGallery.java
+++ b/MediaPicker/multiple-media-picker/src/main/java/com/erikagtierrez/multiple_media_picker/OpenGallery.java
@@ -24,7 +24,6 @@ public class OpenGallery extends AppCompatActivity {
     private RecyclerView recyclerView;
     private MediaAdapter mAdapter;
     private List<String> mediaList=new ArrayList<>();
-    private List<String> mediaPicked =new ArrayList<>();
     public static List<Boolean> selected=new ArrayList<>();
     public static ArrayList<String> imagesSelected=new ArrayList<>();
     public static String parent;
@@ -71,7 +70,7 @@ public class OpenGallery extends AppCompatActivity {
 
 
     private void populateRecyclerView() {
-        for(int i=0;i<selected.size()-1;i++){
+        for(int i=0;i<selected.size();i++){
             if(imagesSelected.contains(mediaList.get(i))){
                 selected.set(i,true);
             }else {
@@ -88,11 +87,9 @@ public class OpenGallery extends AppCompatActivity {
             public void onClick(View view, int position) {
                 if(!selected.get(position).equals(true)){
                     imagesSelected.add(mediaList.get(position));
-                    mediaPicked.add(mediaList.get(position));
                 }else {
                     if(imagesSelected.indexOf(mediaList.get(position))!= -1) {
                         imagesSelected.remove(imagesSelected.indexOf(mediaList.get(position)));
-                        mediaPicked.remove(mediaPicked.indexOf(mediaList.get(position)));
                     }
                 }
                 Gallery.selectionTitle=imagesSelected.size();
@@ -110,52 +107,52 @@ public class OpenGallery extends AppCompatActivity {
 
             }
         }));
-        }
-
-        public interface ClickListener {
-            void onClick(View view, int position);
-            void onLongClick(View view, int position);
-        }
-
-        public static class RecyclerTouchListener implements RecyclerView.OnItemTouchListener {
-            private GestureDetector gestureDetector;
-            private OpenGallery.ClickListener clickListener;
-
-            public RecyclerTouchListener(Context context, final RecyclerView recyclerView, final OpenGallery.ClickListener clickListener) {
-                this.clickListener = clickListener;
-                gestureDetector = new GestureDetector(context, new GestureDetector.SimpleOnGestureListener() {
-                    @Override
-                    public boolean onSingleTapUp(MotionEvent e) {
-                        return true;
-                    }
-
-                    @Override
-                    public void onLongPress(MotionEvent e) {
-                        View child = recyclerView.findChildViewUnder(e.getX(), e.getY());
-                        if (child != null && clickListener != null) {
-                            clickListener.onLongClick(child, recyclerView.getChildPosition(child));
-                        }
-                    }
-                });
-            }
-
-            @Override
-            public boolean onInterceptTouchEvent(RecyclerView rv, MotionEvent e) {
-                View child = rv.findChildViewUnder(e.getX(), e.getY());
-                if (child != null && clickListener != null && gestureDetector.onTouchEvent(e)) {
-                    clickListener.onClick(child, rv.getChildPosition(child));
-                }
-                return false;
-            }
-
-            @Override
-            public void onTouchEvent(RecyclerView rv, MotionEvent e) {
-            }
-
-            @Override
-            public void onRequestDisallowInterceptTouchEvent(boolean disallowIntercept) {
-            }
-        }
-
     }
+
+    public interface ClickListener {
+        void onClick(View view, int position);
+        void onLongClick(View view, int position);
+    }
+
+    public static class RecyclerTouchListener implements RecyclerView.OnItemTouchListener {
+        private GestureDetector gestureDetector;
+        private OpenGallery.ClickListener clickListener;
+
+        public RecyclerTouchListener(Context context, final RecyclerView recyclerView, final OpenGallery.ClickListener clickListener) {
+            this.clickListener = clickListener;
+            gestureDetector = new GestureDetector(context, new GestureDetector.SimpleOnGestureListener() {
+                @Override
+                public boolean onSingleTapUp(MotionEvent e) {
+                    return true;
+                }
+
+                @Override
+                public void onLongPress(MotionEvent e) {
+                    View child = recyclerView.findChildViewUnder(e.getX(), e.getY());
+                    if (child != null && clickListener != null) {
+                        clickListener.onLongClick(child, recyclerView.getChildPosition(child));
+                    }
+                }
+            });
+        }
+
+        @Override
+        public boolean onInterceptTouchEvent(RecyclerView rv, MotionEvent e) {
+            View child = rv.findChildViewUnder(e.getX(), e.getY());
+            if (child != null && clickListener != null && gestureDetector.onTouchEvent(e)) {
+                clickListener.onClick(child, rv.getChildPosition(child));
+            }
+            return false;
+        }
+
+        @Override
+        public void onTouchEvent(RecyclerView rv, MotionEvent e) {
+        }
+
+        @Override
+        public void onRequestDisallowInterceptTouchEvent(boolean disallowIntercept) {
+        }
+    }
+
+}
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Multiple Media Picker :boom: :star2:
 ### An android library to pick multiple images and/or videos from built-in gallery. This library is encouraged to use as little memory as possible. 
 
-[![Join the chat at https://gitter.im/Multiple-Media-Picker/Lobby](https://badges.gitter.im/Multiple-Media-Picker/Lobby.svg)](https://gitter.im/Multiple-Media-Picker/Lobby?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge) ![](https://img.shields.io/badge/license-APACHE%202-ff69b4.svg) ![](	https://img.shields.io/badge/bintray-v.1.0.2-673AB7.svg)
+[![Join the chat at https://gitter.im/Multiple-Media-Picker/Lobby](https://badges.gitter.im/Multiple-Media-Picker/Lobby.svg)](https://gitter.im/Multiple-Media-Picker/Lobby?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge) ![](https://img.shields.io/badge/license-APACHE%202-ff69b4.svg) ![](	https://img.shields.io/badge/bintray-v.1.0.1-673AB7.svg)
 
 ![](https://raw.githubusercontent.com/erikagtierrez/multiple-media-picker/master/cover.jpg)
 


### PR DESCRIPTION
Bug Fixed, Unnecessary variable deleted.
Only one image in folder was not recognized to be selected when re-entered OpenGallery Activity - FIXED
Unselecting image when re-entered OpenGallery Activity occurred app crashing - FIXED by removing variable mediaPicked

At first I made restoreMediaPicked function, but it seemed unnecessary, so I just deleted it.
If you declared it for future usage,  just call restoreMediaPicked function before populateRecyclerView called

restoreMediaPicked should retrieve picked images from imagesSelected.
The problem occurs because mediaPicked array is empty when re-entered OpenGallery Activity.